### PR TITLE
Allow computation at new timepoints

### DIFF
--- a/R/sbrier.R
+++ b/R/sbrier.R
@@ -109,6 +109,10 @@ sbrier <- function(obj, pred, btime = range(obj[,1]))
     # hatcdist <- survfit(Surv(time, 1 - cens) ~ 1)
     # csurv <- getsurv(hatcdist, time)
     # csurv[csurv == 0] <- Inf
+    
+    # conditional survival for new timepoints
+    csurv_btime <- predict(hatcdist, times = btime, type = "surv")
+    csurv_btime[is.na(csurv_btime)] <- min(csurv_btime, na.rm = TRUE)
 
     bsc <- rep(0, length(btime))
     
@@ -119,7 +123,7 @@ sbrier <- function(obj, pred, btime = range(obj[,1]))
             help1 <- as.integer(time <= btime[j] & cens == 1)
             help2 <- as.integer(time > btime[j])
             bsc[j] <-  mean((0 - survs[j,])^2*help1*(1/csurv) +
-                            (1-survs[j,])^2*help2*(1/csurv[j]))
+                            (1-survs[j,])^2*help2*(1/csurv_btime[j]))
         }
 
         ### apply trapezoid rule


### PR DESCRIPTION
If `pred` is a matrix, `sbrier()` returns `NA` if the time points in `obj` are different than those in `btime`. Example: 

````R

library(survival)
library(ipred)
library(ranger)

# Train and test data
set.seed(100)
train_idx <- sample(1:nrow(veteran), 0.7*nrow(veteran))
train <- veteran[train_idx, ]
test <- veteran[-train_idx, ]

# Predict on train data
# Same timepoints in obj and btime -> working 
rf <- ranger(Surv(time, status) ~ ., data = train)
pred <- predict(rf, train)$survival
sbrier(obj = Surv(train$time, train$status), pred = t(pred), btime = timepoints(rf))

# Predict on test data
# Different timepoints in obj and btime -> not working (fixed in this PR)
rf <- ranger(Surv(time, status) ~ ., data = train)
pred <- predict(rf, test)$survival
sbrier(obj = Surv(test$time, test$status), pred = t(pred), btime = timepoints(rf))
````

The problem is that the conditional survival is only computed for the time in `obj` but not for `btime`. This is fixed in this PR. 

This gives consistent results with the `pec` package (there still is a slightly different integration algorithm but the result before integration is the same). 